### PR TITLE
fix update in setMovieRatingFn to render instantly without refetchQue…

### DIFF
--- a/frontend/src/routes/Movie/MovieContainer.tsx
+++ b/frontend/src/routes/Movie/MovieContainer.tsx
@@ -1,14 +1,14 @@
-import React, { Component } from 'react';
-import { RouteComponentProps } from 'react-router-dom';
-import { Query, Mutation, MutationFn } from 'react-apollo';
+import React, { Component } from "react";
+import { RouteComponentProps } from "react-router-dom";
+import { Query, Mutation, MutationFn } from "react-apollo";
 import {
   getMovieDetail,
   setMovieRating,
   setMovieRatingVariables
-} from 'src/types/api';
-import MoviePresenter from './MoviePresenter';
-import { GET_MOVIE_DETAIL, SET_MOVIE_RATING } from './MovieQueries';
-import Loading from 'src/components/Loading';
+} from "src/types/api";
+import MoviePresenter from "./MoviePresenter";
+import { GET_MOVIE_DETAIL, SET_MOVIE_RATING } from "./MovieQueries";
+import Loading from "src/components/Loading";
 
 interface IState {
   rating: number;
@@ -42,12 +42,12 @@ export class MovieContainer extends Component<IProps, IState> {
       variables: { movieId, rating },
       optimisticResponse: {
         SetMovieRating: {
-          __typename: 'SetMovieRatingResponse',
+          __typename: "SetMovieRatingResponse",
           ok: rating ? true : false,
           type: null,
           error: null,
           movieRating: {
-            __typename: 'MovieRating',
+            __typename: "MovieRating",
             id: null,
             rating,
             userId: null,
@@ -61,13 +61,17 @@ export class MovieContainer extends Component<IProps, IState> {
           query: GET_MOVIE_DETAIL,
           variables: { movieId }
         });
+        console.log(data);
         const newData = {
           ...data,
           GetMovieRating: SetMovieRating
         };
-        store.writeQuery({ query: GET_MOVIE_DETAIL, data: newData });
-      },
-      refetchQueries: () => ['getMovieDetail']
+        store.writeQuery({
+          query: GET_MOVIE_DETAIL,
+          variables: { movieId },
+          data: newData
+        });
+      }
     });
   };
 

--- a/frontend/src/routes/Movie/MoviePresenter.tsx
+++ b/frontend/src/routes/Movie/MoviePresenter.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import Helmet from 'react-helmet';
-import styled from 'styled-components';
-import { Alert, Card } from 'antd';
-import MovieRating from 'src/components/MovieRating';
+import React from "react";
+import Helmet from "react-helmet";
+import styled from "styled-components";
+import { Alert, Card } from "antd";
+import MovieRating from "src/components/MovieRating";
 
 const MovieInfoContinaer = styled.div`
   background-color: #fff;
@@ -57,7 +57,7 @@ const MoviePresenter = ({ data, handleClickMovieRating }) => {
     GetMovieDetail: { ok, movie },
     GetMovieRating: { ok: ratingOk, movieRating }
   } = data;
-  console.log(data);
+  // console.log(data);
   return (
     <>
       {ok ? (
@@ -87,11 +87,11 @@ const MoviePresenter = ({ data, handleClickMovieRating }) => {
                 description={
                   <React.Fragment>
                     <GenreWrapper>
-                      {movie.genres.map(genre => genre.name).join(' ')}
+                      {movie.genres.map(genre => genre.name).join(" ")}
                     </GenreWrapper>
-                    <div>{movie.release_date.replace(/-/gi, '. ')}</div>
+                    <div>{movie.release_date.replace(/-/gi, ". ")}</div>
                     <MovieRating
-                      rating={ratingOk ? movieRating.rating : 0}
+                      rating={ratingOk && movieRating ? movieRating.rating : 0}
                       handleClickMovieRating={handleClickMovieRating}
                     />
                   </React.Fragment>


### PR DESCRIPTION
[PR 목적]

영화 Detail page에서 rating을 새로 추가하거나 기존 rating을 없애는 경우, 지연이 발생하는 이유는 mutation 후 refetchQueries를 실행하기 때문. 이로 인한 지연을 없애기 위해 아래 내용 수정.

== MovieContainer.tsx ==
1. MovieRatingMutation Component에서 setMovieRatingFn으로 mutation 이후, cache update시 writeQuery에 기존 Root Query와 동일하게 `variables: { movieId }`를 주어 Root Query가 업데이트 되도록 수정.

== MoviePresenter.tsx ==
2. Rating을 한 후, Rating을 지우는 경우 movieRating 값이 null을 가지게 되어, rating props에 moiveRating 조건 추가.